### PR TITLE
Issue #1 Allow overriding of headers, particularly when file has no headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
 
 		<jackson.version>2.8.7</jackson.version>
 		<junit.version>4.12</junit.version>
-		<slf4j.version>1.7.23</slf4j.version>
+		<slf4j.version>1.7.25</slf4j.version>
 		<rdf4j.version>2.2</rdf4j.version>
-		<schemagenerator.version>0.3-SNAPSHOT</schemagenerator.version>
+		<schemagenerator.version>0.3</schemagenerator.version>
 	</properties>
 	<prerequisites>
 		<maven>3.0.5</maven>
@@ -107,7 +107,7 @@
 			<dependency>
 				<groupId>com.github.ansell.csv.sum</groupId>
 				<artifactId>csvsum</artifactId>
-				<version>0.4.1-SNAPSHOT</version>
+				<version>0.4.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
@@ -152,7 +152,7 @@
 			<dependency>
 				<groupId>net.sf.jopt-simple</groupId>
 				<artifactId>jopt-simple</artifactId>
-				<version>5.0.1</version>
+				<version>5.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>
@@ -191,7 +191,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-vfs2</artifactId>
-				<version>2.0</version>
+				<version>2.1</version>
 			</dependency>
 			<dependency>
 				<groupId>net.java.dev.stax-utils</groupId>
@@ -314,7 +314,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.3</version>
+					<version>2.10.4</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -324,7 +324,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.7</version>
+					<version>3.0.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -356,7 +356,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>2.4</version>
+					<version>3.0.1</version>
 					<executions>
 						<execution>
 							<id>attach-source</id>
@@ -375,7 +375,7 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.7.6.201602180812</version>
+					<version>0.7.7.201606060606</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -395,7 +395,7 @@
 				<plugin>
 					<groupId>org.eluder.coveralls</groupId>
 					<artifactId>coveralls-maven-plugin</artifactId>
-					<version>4.1.0</version>
+					<version>4.2.0</version>
 				</plugin>
 				<plugin>
 					<groupId>com.github.ansell.rdf4j-schema-generator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 			<dependency>
 				<groupId>com.github.ansell.csv.sum</groupId>
 				<artifactId>csvsum</artifactId>
-				<version>0.4.0</version>
+				<version>0.4.1-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>

--- a/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveChecker.java
+++ b/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveChecker.java
@@ -135,7 +135,7 @@ public class DarwinCoreArchiveChecker {
     			// Only support a single core file
     			String coreFileName = core.getFiles().getLocations().get(0);
     			Path coreFilePath = metadataPath.resolveSibling(coreFileName).normalize().toAbsolutePath();
-    			try (Reader inputReader = Files.newBufferedReader(metadataPath.resolveSibling(coreFileName), core.getEncoding());
+    			try (Reader inputReader = Files.newBufferedReader(coreFilePath, core.getEncoding());
     			        Writer summaryWriter = Files.newBufferedWriter(outputDirPath.resolve("Statistics-" + coreFilePath.getFileName().toString()), core.getEncoding());
     			        Writer mappingWriter = Files.newBufferedWriter(outputDirPath.resolve("Mapping-" + coreFilePath.getFileName().toString()), core.getEncoding());
     			    )

--- a/src/main/java/com/github/ansell/dwca/DarwinCoreMetadataGenerator.java
+++ b/src/main/java/com/github/ansell/dwca/DarwinCoreMetadataGenerator.java
@@ -155,7 +155,7 @@ public class DarwinCoreMetadataGenerator {
 				}, (h, l) -> {
 					return l;
 				}, l -> {
-				}, null, CSVStream.DEFAULT_HEADER_COUNT);
+				});
 			}
 		}
 

--- a/src/main/java/com/github/ansell/dwca/DarwinCoreMetadataGenerator.java
+++ b/src/main/java/com/github/ansell/dwca/DarwinCoreMetadataGenerator.java
@@ -89,17 +89,17 @@ public class DarwinCoreMetadataGenerator {
 
 		final OptionSpec<Void> help = parser.accepts("help").forHelp();
 		final OptionSpec<File> input = parser.accepts("input").withRequiredArg().ofType(File.class).required()
-				.describedAs("The input CSV file to be parsed.");
+				.describedAs("The core input CSV file to be parsed.");
 		final OptionSpec<File> overrideHeadersFile = parser.accepts("override-headers-file").withRequiredArg()
 				.ofType(File.class).describedAs(
-						"A file whose first line contains the headers to use, to override those found in the file.");
+						"A file whose first line contains the headers to use, to override those found in the core file.");
 		final OptionSpec<Integer> headerLineCount = parser.accepts("header-line-count").withRequiredArg()
 				.ofType(Integer.class)
 				.describedAs(
-						"The number of header lines present in the file. Can be used in conjunction with override-headers-file to substitute a different set of headers")
+						"The number of header lines present in the core input file. Can be used in conjunction with override-headers-file to substitute a different set of headers")
 				.defaultsTo(1);
 		final OptionSpec<File> extensionOption = parser.accepts("extension").withRequiredArg().ofType(File.class)
-				.describedAs("Extension CSV files to be included. May be used multiple times if needed.");
+				.describedAs("Extension CSV files to be included. May be used multiple times if needed. They must contain a single header line");
 		final OptionSpec<File> output = parser.accepts("output").withRequiredArg().ofType(File.class).required()
 				.describedAs("The output metadata.xml file to be generated.");
 		final OptionSpec<Boolean> showDefaults = parser.accepts("show-defaults").withOptionalArg().ofType(Boolean.class)

--- a/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
+++ b/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
@@ -141,6 +141,14 @@ public class DarwinCoreArchiveCheckerTest {
 	 */
 	@Test
 	public final void testMain() throws Exception {
+//	    com.github.ansell.csv.stream.CSVStreamException: Line and header sizes were different: 
+//	    [http://rs.tdwg.org/dwc/terms/catalogNumber, http://rs.tdwg.org/dwc/terms/scientificName, http://rs.tdwg.org/dwc/terms/individualCount, http://rs.tdwg.org/dwc/terms/datasetID] 
+//      [123,                                        Cryptantha gypsophila Reveal & C.R. Broome,  12]
+//	        at com.github.ansell.csv.stream.CSVStream.parse(CSVStream.java:236)
+//	        at com.github.ansell.csv.sum.CSVSummariser.runSummarise(CSVSummariser.java:236)
+//	        at com.github.ansell.dwca.DarwinCoreArchiveChecker.main(DarwinCoreArchiveChecker.java:142)
+//	        at com.github.ansell.dwca.DarwinCoreArchiveCheckerTest.testMain(DarwinCoreArchiveCheckerTest.java:144)
+
 		DarwinCoreArchiveChecker.main("--input", testFile.toAbsolutePath().toString());
 	}
 

--- a/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
+++ b/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
@@ -141,14 +141,6 @@ public class DarwinCoreArchiveCheckerTest {
 	 */
 	@Test
 	public final void testMain() throws Exception {
-//	    com.github.ansell.csv.stream.CSVStreamException: Line and header sizes were different: 
-//	    [http://rs.tdwg.org/dwc/terms/catalogNumber, http://rs.tdwg.org/dwc/terms/scientificName, http://rs.tdwg.org/dwc/terms/individualCount, http://rs.tdwg.org/dwc/terms/datasetID] 
-//      [123,                                        Cryptantha gypsophila Reveal & C.R. Broome,  12]
-//	        at com.github.ansell.csv.stream.CSVStream.parse(CSVStream.java:236)
-//	        at com.github.ansell.csv.sum.CSVSummariser.runSummarise(CSVSummariser.java:236)
-//	        at com.github.ansell.dwca.DarwinCoreArchiveChecker.main(DarwinCoreArchiveChecker.java:142)
-//	        at com.github.ansell.dwca.DarwinCoreArchiveCheckerTest.testMain(DarwinCoreArchiveCheckerTest.java:144)
-
 		DarwinCoreArchiveChecker.main("--input", testFile.toAbsolutePath().toString());
 	}
 

--- a/src/test/resources/com/github/ansell/dwca/specimens.csv
+++ b/src/test/resources/com/github/ansell/dwca/specimens.csv
@@ -1,3 +1,3 @@
-"ID","Species","Count"
-123,"Cryptantha gypsophila Reveal & C.R. Broome",12
-124,"Buxbaumia piperi",2
+ID,Species,Count,DatasetID
+123,Cryptantha gypsophila Reveal & C.R. Broome,12,A1
+124,Buxbaumia piperi,2,A1


### PR DESCRIPTION
Need to be able to cope with files in DwCA archives that have no header lines, and rely instead on the meta.xml file to describe the fields that are available. This adds that capability, and also adds the capability to generate statistics using the field names from the meta.xml file, which is otherwise hard to do with any other tool.