### PR TITLE
Fix #4 Push quote/separator/line ending characters into CSV parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: java
 sudo: false
-cache:
-  directories:
-    - $HOME/.m2
 jdk:
   - oraclejdk8
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dwca-utils
 
-Darwin Core Archive Utils
+Darwin Core Archive Utils for parsing archives that are compliant with the [Darwin Core Text Guide](http://rs.tdwg.org/dwc/terms/guides/text/)
 
 [![Build Status](https://travis-ci.org/ansell/dwca-utils.svg?branch=master)](https://travis-ci.org/ansell/dwca-utils) [![Coverage Status](https://coveralls.io/repos/ansell/dwca-utils/badge.svg?branch=master)](https://coveralls.io/r/ansell/dwca-utils?branch=master)
 
@@ -17,6 +17,8 @@ Set the relevant programs to be executable.
 
 # Darwin Core Archive Checker
 
+Checks that archives are compliant with the Darwin Core Text Guide
+
 ## Usage
 
 Run dwcacheck with --help to get usage details:
@@ -24,6 +26,8 @@ Run dwcacheck with --help to get usage details:
     ./dwcacheck --help
 
 # Darwin Core Metadata Generator
+
+Generates Darwin Core Text metadata.xml files based on given core and extension files.
 
 ## Usage
 
@@ -40,6 +44,10 @@ Run csv2dwca with --help to get usage details:
     </dependency>
 
 # Changelog
+
+## 2017-06-07
+* Check extension files when using dwcacheck
+* Pass quote/field separator/line ending information from metadata.xml through to CSV parser
 
 ## 2017-04-03
 * Release 0.0.3

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,12 @@
 			<dependency>
 				<groupId>com.github.ansell.csv.sum</groupId>
 				<artifactId>csvsum</artifactId>
-				<version>0.4.1</version>
+				<version>0.4.2-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.ansell.csv</groupId>
+				<artifactId>csvstream</artifactId>
+				<version>0.0.3-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>

--- a/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveChecker.java
+++ b/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveChecker.java
@@ -140,20 +140,21 @@ public class DarwinCoreArchiveChecker {
             String coreFileName = core.getFiles().getLocations().get(0);
             Path coreFilePath = metadataPath.resolveSibling(coreFileName).normalize()
                     .toAbsolutePath();
-            try (Reader inputReader = Files.newBufferedReader(coreFilePath, core.getEncoding());
-                    Writer summaryWriter = Files.newBufferedWriter(
+            try (Reader inputReader = Files.newBufferedReader(coreFilePath, core.getEncoding());) {
+                if (options.has(output)) {
+                    try (Writer summaryWriter = Files.newBufferedWriter(
                             outputDirPath
                                     .resolve("Statistics-" + coreFilePath.getFileName().toString()),
                             core.getEncoding());
-                    Writer mappingWriter = Files.newBufferedWriter(
-                            outputDirPath
-                                    .resolve("Mapping-" + coreFilePath.getFileName().toString()),
-                            core.getEncoding());) {
-                if (options.has(output)) {
-                    // Summarise the core document
-                    CSVSummariser.runSummarise(inputReader, CSVStream.defaultMapper(),
-                            core.getCsvSchema(), summaryWriter, mappingWriter, 20, true, debug,
-                            coreFields, headerLineCount);
+                            Writer mappingWriter = Files.newBufferedWriter(
+                                    outputDirPath.resolve(
+                                            "Mapping-" + coreFilePath.getFileName().toString()),
+                                    core.getEncoding());) {
+                        // Summarise the core document
+                        CSVSummariser.runSummarise(inputReader, CSVStream.defaultMapper(),
+                                core.getCsvSchema(), summaryWriter, mappingWriter, 20, true, debug,
+                                coreFields, headerLineCount);
+                    }
                 } else {
                     CSVStream.parse(inputReader, h -> {
                     }, (h, l) -> l, l -> {

--- a/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveChecker.java
+++ b/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveChecker.java
@@ -43,6 +43,7 @@ import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.VFS;
 import org.xml.sax.SAXException;
 
+import com.github.ansell.csv.stream.CSVStream;
 import com.github.ansell.csv.sum.CSVSummariser;
 
 import joptsimple.OptionException;
@@ -58,165 +59,183 @@ import joptsimple.OptionSpec;
  */
 public class DarwinCoreArchiveChecker {
 
-	public static final String METADATA_XML = "metadata.xml";
-	public static final String META_XML = "meta.xml";
+    public static final String METADATA_XML = "metadata.xml";
+    public static final String META_XML = "meta.xml";
 
-	/**
-	 * Private constructor for static only class
-	 */
-	private DarwinCoreArchiveChecker() {
-	}
+    /**
+     * Private constructor for static only class
+     */
+    private DarwinCoreArchiveChecker() {
+    }
 
-	public static void main(String... args) throws Exception {
-		final OptionParser parser = new OptionParser();
+    public static void main(String... args) throws Exception {
+        final OptionParser parser = new OptionParser();
 
-		final OptionSpec<Void> help = parser.accepts("help").forHelp();
-		final OptionSpec<File> input = parser.accepts("input").withRequiredArg().ofType(File.class).required()
-				.describedAs("The input Darwin Core Archive file or metadata file to be checked.");
-		final OptionSpec<File> output = parser.accepts("output").withRequiredArg().ofType(File.class)
-		        .describedAs("A directory to output summary and other files to. If this is not set, no output will be preserved.");
-		final OptionSpec<Boolean> debugOption = parser.accepts("debug").withRequiredArg().ofType(Boolean.class).defaultsTo(Boolean.FALSE)
-				.describedAs("Set to true to debug.");
+        final OptionSpec<Void> help = parser.accepts("help").forHelp();
+        final OptionSpec<File> input = parser.accepts("input").withRequiredArg().ofType(File.class)
+                .required()
+                .describedAs("The input Darwin Core Archive file or metadata file to be checked.");
+        final OptionSpec<File> output = parser.accepts("output").withRequiredArg()
+                .ofType(File.class).describedAs(
+                        "A directory to output summary and other files to. If this is not set, no output will be preserved.");
+        final OptionSpec<Boolean> debugOption = parser.accepts("debug").withRequiredArg()
+                .ofType(Boolean.class).defaultsTo(Boolean.FALSE)
+                .describedAs("Set to true to debug.");
 
-		OptionSet options = null;
+        OptionSet options = null;
 
-		try {
-			options = parser.parse(args);
-		} catch (final OptionException e) {
-			System.out.println(e.getMessage());
-			parser.printHelpOn(System.out);
-			throw e;
-		}
+        try {
+            options = parser.parse(args);
+        } catch (final OptionException e) {
+            System.out.println(e.getMessage());
+            parser.printHelpOn(System.out);
+            throw e;
+        }
 
-		if (options.has(help)) {
-			parser.printHelpOn(System.out);
-			return;
-		}
+        if (options.has(help)) {
+            parser.printHelpOn(System.out);
+            return;
+        }
 
-		final boolean debug = debugOption.value(options);
-		
-		final Path inputPath = input.value(options).toPath();
-		if (!Files.exists(inputPath)) {
-			throw new FileNotFoundException(
-					"Could not find input Darwin Core Archive file or metadata file: " + inputPath.toString());
-		}
+        final boolean debug = debugOption.value(options);
 
-		final Path tempDir = Files.createTempDirectory("dwca-check-");
+        final Path inputPath = input.value(options).toPath();
+        if (!Files.exists(inputPath)) {
+            throw new FileNotFoundException(
+                    "Could not find input Darwin Core Archive file or metadata file: "
+                            + inputPath.toString());
+        }
 
-		try {
-	        final Path outputDirPath;
-	        if(options.has(output)) {
-	            outputDirPath = output.value(options).toPath();
-	        } else {
-	            outputDirPath = tempDir;
-	        }
-	        
-			final Path metadataPath;
-			if (inputPath.getFileName().toString().contains(".zip")) {
-				metadataPath = checkZip(inputPath, tempDir);
-				if (metadataPath == null) {
-					throw new IllegalStateException(
-							"Did not find a metadata file in the ZIP file: " + inputPath.toAbsolutePath().toString());
-				}
-			} else {
-				metadataPath = inputPath;
-			}
-	
-			DarwinCoreArchiveDocument archiveDocument = parseMetadataXml(metadataPath);
-			if(debug) {
-				System.out.println(archiveDocument.toString());
-			}
-			
-			if(options.has(output)) {
-    			// Summarise the core document
-    			DarwinCoreCoreOrExtension core = archiveDocument.getCore();
-    			int headerLineCount = core.getIgnoreHeaderLines();
-    			List<String> coreFields = core.getFields().stream().map(f -> f.getTerm()).collect(Collectors.toList());
-    			// Only support a single core file
-    			String coreFileName = core.getFiles().getLocations().get(0);
-    			Path coreFilePath = metadataPath.resolveSibling(coreFileName).normalize().toAbsolutePath();
-    			try (Reader inputReader = Files.newBufferedReader(coreFilePath, core.getEncoding());
-    			        Writer summaryWriter = Files.newBufferedWriter(outputDirPath.resolve("Statistics-" + coreFilePath.getFileName().toString()), core.getEncoding());
-    			        Writer mappingWriter = Files.newBufferedWriter(outputDirPath.resolve("Mapping-" + coreFilePath.getFileName().toString()), core.getEncoding());
-    			    )
-    			{
-    			    CSVSummariser.runSummarise(inputReader, summaryWriter, mappingWriter, 20, true, debug, coreFields, headerLineCount);
-    			}
-			}
-		} finally {
-			FileUtils.deleteQuietly(tempDir.toFile());
-		}
-	}
+        final Path tempDir = Files.createTempDirectory("dwca-check-");
 
-	/**
-	 * Checks that the zip file given in inputPath contains a valid structure
-	 * for a Darwin Core Archive zip file, while extracting it to tempDir.
-	 * 
-	 * @param inputPath
-	 *            The Darwin Core Archive zip file.
-	 * @param tempDir
-	 *            The temporary directory to extract the zip file to.
-	 * @return The path to the extracted metadata.xml file, if it existed,
-	 *         otherwise null.
-	 * @throws IOException
-	 *             If there is an input-output exception.
-	 */
-	public static Path checkZip(Path inputPath, Path tempDir) throws IOException {
-		Path metadataPath = null;
+        try {
+            final Path outputDirPath;
+            if (options.has(output)) {
+                outputDirPath = output.value(options).toPath();
+            } else {
+                outputDirPath = tempDir;
+            }
 
-		final FileSystemManager fsManager = VFS.getManager();
-		final FileObject zipFile = fsManager.resolveFile("zip:" + inputPath.toAbsolutePath().toString());
+            final Path metadataPath;
+            if (inputPath.getFileName().toString().contains(".zip")) {
+                metadataPath = checkZip(inputPath, tempDir);
+                if (metadataPath == null) {
+                    throw new IllegalStateException("Did not find a metadata file in the ZIP file: "
+                            + inputPath.toAbsolutePath().toString());
+                }
+            } else {
+                metadataPath = inputPath;
+            }
 
-		final FileObject[] children = zipFile.getChildren();
-		if (children.length == 0) {
-			throw new RuntimeException("No files in zip file: " + inputPath);
-		}
+            DarwinCoreArchiveDocument archiveDocument = parseMetadataXml(metadataPath);
+            if (debug) {
+                System.out.println(archiveDocument.toString());
+            }
 
-		for (FileObject nextFile : children) {
-			try (InputStream in = nextFile.getContent().getInputStream();) {
-				String baseName = nextFile.getName().getBaseName();
-				Path nextTempFile = tempDir.resolve(baseName);
-				if (baseName.equalsIgnoreCase(METADATA_XML) || baseName.equalsIgnoreCase(META_XML)) {
-					if (metadataPath != null) {
-						throw new RuntimeException("Duplicate metadata.xml files found: original=" + metadataPath
-								+ " duplicate=" + baseName);
-					}
-					metadataPath = nextTempFile;
-				}
+            DarwinCoreCoreOrExtension core = archiveDocument.getCore();
+            int headerLineCount = core.getIgnoreHeaderLines();
+            List<String> coreFields = core.getFields().stream().map(f -> f.getTerm())
+                    .collect(Collectors.toList());
+            // Only support a single core file
+            String coreFileName = core.getFiles().getLocations().get(0);
+            Path coreFilePath = metadataPath.resolveSibling(coreFileName).normalize()
+                    .toAbsolutePath();
+            try (Reader inputReader = Files.newBufferedReader(coreFilePath, core.getEncoding());
+                    Writer summaryWriter = Files.newBufferedWriter(
+                            outputDirPath
+                                    .resolve("Statistics-" + coreFilePath.getFileName().toString()),
+                            core.getEncoding());
+                    Writer mappingWriter = Files.newBufferedWriter(
+                            outputDirPath
+                                    .resolve("Mapping-" + coreFilePath.getFileName().toString()),
+                            core.getEncoding());) {
+                if (options.has(output)) {
+                    // Summarise the core document
+                    CSVSummariser.runSummarise(inputReader, CSVStream.defaultMapper(),
+                            core.getCsvSchema(), summaryWriter, mappingWriter, 20, true, debug,
+                            coreFields, headerLineCount);
+                } else {
+                    CSVStream.parse(inputReader, h -> {
+                    }, (h, l) -> l, l -> {
+                    }, coreFields, headerLineCount, CSVStream.defaultMapper(), core.getCsvSchema());
+                }
+            }
+        } finally {
+            FileUtils.deleteQuietly(tempDir.toFile());
+        }
+    }
 
-				Files.copy(in, nextTempFile);
-			}
-		}
+    /**
+     * Checks that the zip file given in inputPath contains a valid structure
+     * for a Darwin Core Archive zip file, while extracting it to tempDir.
+     * 
+     * @param inputPath
+     *            The Darwin Core Archive zip file.
+     * @param tempDir
+     *            The temporary directory to extract the zip file to.
+     * @return The path to the extracted metadata.xml file, if it existed,
+     *         otherwise null.
+     * @throws IOException
+     *             If there is an input-output exception.
+     */
+    public static Path checkZip(Path inputPath, Path tempDir) throws IOException {
+        Path metadataPath = null;
 
-		if (metadataPath == null) {
-			throw new IllegalStateException(
-					"Did not find a metadata file in the ZIP file: " + inputPath.toAbsolutePath().toString());
-		}
+        final FileSystemManager fsManager = VFS.getManager();
+        final FileObject zipFile = fsManager
+                .resolveFile("zip:" + inputPath.toAbsolutePath().toString());
 
-		return metadataPath;
-	}
+        final FileObject[] children = zipFile.getChildren();
+        if (children.length == 0) {
+            throw new RuntimeException("No files in zip file: " + inputPath);
+        }
 
-	/**
-	 * Parses the metadata.xml file.
-	 * 
-	 * @param metadataPath
-	 *            The path to the metadata.xml file to parse.
-	 * @return An instance of {@link DarwinCoreArchiveDocument} representing the
-	 *         parsed document.
-	 * @throws IOException
-	 *             If there is an input-output exception.
-	 * @throws SAXException
-	 *             If there is an exception parsing the XML document.
-	 * @throws IllegalStateException
-	 *             If there is an exception interpreting the context of parts of
-	 *             the document that violate the state assumptions in the
-	 *             specification.
-	 */
-	public static DarwinCoreArchiveDocument parseMetadataXml(Path metadataPath)
-			throws IOException, SAXException, IllegalStateException {
-		try (Reader input = Files.newBufferedReader(metadataPath);) {
-			return DarwinCoreMetadataSaxParser.parse(input);
-		}
-	}
+        for (FileObject nextFile : children) {
+            try (InputStream in = nextFile.getContent().getInputStream();) {
+                String baseName = nextFile.getName().getBaseName();
+                Path nextTempFile = tempDir.resolve(baseName);
+                if (baseName.equalsIgnoreCase(METADATA_XML)
+                        || baseName.equalsIgnoreCase(META_XML)) {
+                    if (metadataPath != null) {
+                        throw new RuntimeException("Duplicate metadata.xml files found: original="
+                                + metadataPath + " duplicate=" + baseName);
+                    }
+                    metadataPath = nextTempFile;
+                }
+
+                Files.copy(in, nextTempFile);
+            }
+        }
+
+        if (metadataPath == null) {
+            throw new IllegalStateException("Did not find a metadata file in the ZIP file: "
+                    + inputPath.toAbsolutePath().toString());
+        }
+
+        return metadataPath;
+    }
+
+    /**
+     * Parses the metadata.xml file.
+     * 
+     * @param metadataPath
+     *            The path to the metadata.xml file to parse.
+     * @return An instance of {@link DarwinCoreArchiveDocument} representing the
+     *         parsed document.
+     * @throws IOException
+     *             If there is an input-output exception.
+     * @throws SAXException
+     *             If there is an exception parsing the XML document.
+     * @throws IllegalStateException
+     *             If there is an exception interpreting the context of parts of
+     *             the document that violate the state assumptions in the
+     *             specification.
+     */
+    public static DarwinCoreArchiveDocument parseMetadataXml(Path metadataPath)
+            throws IOException, SAXException, IllegalStateException {
+        try (Reader input = Files.newBufferedReader(metadataPath);) {
+            return DarwinCoreMetadataSaxParser.parse(input);
+        }
+    }
 
 }

--- a/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveDocument.java
+++ b/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveDocument.java
@@ -39,7 +39,7 @@ import com.github.ansell.dwca.DarwinCoreCoreOrExtension.CoreOrExtension;
 import javanet.staxutils.IndentingXMLStreamWriter;
 
 /**
- * Represents an entire Darwin Core Archive document as parsed into memory.
+ * Represents an entire Darwin Core Archive metadata.xml file as parsed into memory.
  * 
  * @author Peter Ansell p_ansell@yahoo.com
  * @see <a href="http://rs.tdwg.org/dwc/terms/guides/text/">Darwin Core Text
@@ -179,7 +179,7 @@ public class DarwinCoreArchiveDocument {
 				}
 			}
 
-		}
-	}
+        }
+    }
 
 }

--- a/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveDocument.java
+++ b/src/main/java/com/github/ansell/dwca/DarwinCoreArchiveDocument.java
@@ -178,7 +178,6 @@ public class DarwinCoreArchiveDocument {
 							"Fields that do not have indexes must have default values set: " + field.getTerm());
 				}
 			}
-
         }
     }
 

--- a/src/main/java/com/github/ansell/dwca/DarwinCoreCoreOrExtension.java
+++ b/src/main/java/com/github/ansell/dwca/DarwinCoreCoreOrExtension.java
@@ -39,6 +39,9 @@ import javax.xml.stream.XMLStreamWriter;
 
 import org.xml.sax.Attributes;
 
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema.Builder;
+
 /**
  * Represents either a core or an extension element in a Darwin Core Archive XML
  * file.
@@ -49,359 +52,385 @@ import org.xml.sax.Attributes;
  */
 public class DarwinCoreCoreOrExtension {
 
-	public static final DateTimeFormatter DEFAULT_DATE_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE;
+    public static final DateTimeFormatter DEFAULT_DATE_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE;
 
-	public static final String DEFAULT_DATE_FORMAT_PATTERN = "yyyy-MM-dd";
+    public static final String DEFAULT_DATE_FORMAT_PATTERN = "yyyy-MM-dd";
 
-	public static final int DEFAULT_IGNORE_HEADER_LINES = 0;
+    public static final int DEFAULT_IGNORE_HEADER_LINES = 0;
 
-	public static final Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
+    public static final Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
 
-	public static final String DEFAULT_FIELDS_ENCLOSED_BY = "\"";
+    public static final String DEFAULT_FIELDS_ENCLOSED_BY = "\"";
 
-	public static final String DEFAULT_LINES_TERMINATED_BY = "\n";
+    public static final String DEFAULT_LINES_TERMINATED_BY = "\n";
 
-	public static final String DEFAULT_FIELDS_TERMINATED_BY = ",";
+    public static final String DEFAULT_FIELDS_TERMINATED_BY = ",";
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		final int maxLen = 10;
-		StringBuilder builder = new StringBuilder();
-		builder.append("DarwinCoreCoreOrExtension [");
-		if (idOrCoreId != null) {
-			builder.append("idOrCoreId=");
-			builder.append(idOrCoreId);
-			builder.append(", ");
-		}
-		if (rowType != null) {
-			builder.append("rowType=");
-			builder.append(rowType);
-			builder.append(", ");
-		}
-		if (fieldsTerminatedBy != null) {
-			builder.append("fieldsTerminatedBy=");
-			builder.append(fieldsTerminatedBy.replace("\t", "\\t").replace("\b", "\\b"));
-			builder.append(", ");
-		}
-		if (linesTerminatedBy != null) {
-			builder.append("linesTerminatedBy=");
-			builder.append(linesTerminatedBy.replace("\r", "\\r").replace(DEFAULT_LINES_TERMINATED_BY, "\\n"));
-			builder.append(", ");
-		}
-		if (fieldsEnclosedBy != null) {
-			builder.append("fieldsEnclosedBy=");
-			builder.append(fieldsEnclosedBy);
-			builder.append(", ");
-		}
-		if (encoding != null) {
-			builder.append("encoding=");
-			builder.append(encoding);
-			builder.append(", ");
-		}
-		builder.append("ignoreHeaderLines=");
-		builder.append(ignoreHeaderLines);
-		builder.append(", ");
-		if (dateFormatPattern != null) {
-			builder.append("dateFormatPattern=");
-			builder.append(dateFormatPattern);
-			builder.append(", ");
-		}
-		if (type != null) {
-			builder.append("type=");
-			builder.append(type);
-			builder.append(", ");
-		}
-		if (files != null) {
-			builder.append("files=");
-			builder.append(files);
-			builder.append(", ");
-		}
-		if (fields != null) {
-			builder.append("fields=");
-			builder.append(fields.subList(0, Math.min(fields.size(), maxLen)));
-		}
-		builder.append("]");
-		return builder.toString();
-	}
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        final int maxLen = 10;
+        StringBuilder builder = new StringBuilder();
+        builder.append("DarwinCoreCoreOrExtension [");
+        if (idOrCoreId != null) {
+            builder.append("idOrCoreId=");
+            builder.append(idOrCoreId);
+            builder.append(", ");
+        }
+        if (rowType != null) {
+            builder.append("rowType=");
+            builder.append(rowType);
+            builder.append(", ");
+        }
+        if (fieldsTerminatedBy != null) {
+            builder.append("fieldsTerminatedBy=");
+            builder.append(fieldsTerminatedBy.replace("\t", "\\t").replace("\b", "\\b"));
+            builder.append(", ");
+        }
+        if (linesTerminatedBy != null) {
+            builder.append("linesTerminatedBy=");
+            builder.append(linesTerminatedBy.replace("\r", "\\r")
+                    .replace(DEFAULT_LINES_TERMINATED_BY, "\\n"));
+            builder.append(", ");
+        }
+        if (fieldsEnclosedBy != null) {
+            builder.append("fieldsEnclosedBy=");
+            builder.append(fieldsEnclosedBy);
+            builder.append(", ");
+        }
+        if (encoding != null) {
+            builder.append("encoding=");
+            builder.append(encoding);
+            builder.append(", ");
+        }
+        builder.append("ignoreHeaderLines=");
+        builder.append(ignoreHeaderLines);
+        builder.append(", ");
+        if (dateFormatPattern != null) {
+            builder.append("dateFormatPattern=");
+            builder.append(dateFormatPattern);
+            builder.append(", ");
+        }
+        if (type != null) {
+            builder.append("type=");
+            builder.append(type);
+            builder.append(", ");
+        }
+        if (files != null) {
+            builder.append("files=");
+            builder.append(files);
+            builder.append(", ");
+        }
+        if (fields != null) {
+            builder.append("fields=");
+            builder.append(fields.subList(0, Math.min(fields.size(), maxLen)));
+        }
+        builder.append("]");
+        return builder.toString();
+    }
 
-	public enum CoreOrExtension {
-		CORE,
+    public enum CoreOrExtension {
+        CORE,
 
-		EXTENSION
-	}
+        EXTENSION
+    }
 
-	/**
-	 * This is only required if extensions are used.
-	 */
-	private String idOrCoreId;
+    /**
+     * This is only required if extensions are used.
+     */
+    private String idOrCoreId;
 
-	/**
-	 * Spec says that this is required, but also gives a default, so leaving it
-	 * empty by default to check for its existence.
-	 */
-	private String rowType;
+    /**
+     * Spec says that this is required, but also gives a default, so leaving it
+     * empty by default to check for its existence.
+     */
+    private String rowType;
 
-	private String fieldsTerminatedBy = DEFAULT_FIELDS_TERMINATED_BY;
+    private String fieldsTerminatedBy = DEFAULT_FIELDS_TERMINATED_BY;
 
-	private String linesTerminatedBy = DEFAULT_LINES_TERMINATED_BY;
+    private String linesTerminatedBy = DEFAULT_LINES_TERMINATED_BY;
 
-	private String fieldsEnclosedBy = DEFAULT_FIELDS_ENCLOSED_BY;
+    private String fieldsEnclosedBy = DEFAULT_FIELDS_ENCLOSED_BY;
 
-	private Charset encoding = DEFAULT_ENCODING;
+    private Charset encoding = DEFAULT_ENCODING;
 
-	private int ignoreHeaderLines = DEFAULT_IGNORE_HEADER_LINES;
+    private int ignoreHeaderLines = DEFAULT_IGNORE_HEADER_LINES;
 
-	private DateTimeFormatter dateFormatter = DEFAULT_DATE_FORMAT;
+    private DateTimeFormatter dateFormatter = DEFAULT_DATE_FORMAT;
 
-	private String dateFormatPattern = DEFAULT_DATE_FORMAT_PATTERN;
+    private String dateFormatPattern = DEFAULT_DATE_FORMAT_PATTERN;
 
-	private final CoreOrExtension type;
+    private final CoreOrExtension type;
 
-	private DarwinCoreFile files;
+    private DarwinCoreFile files;
 
-	private final List<DarwinCoreField> fields = new ArrayList<>();
+    private final List<DarwinCoreField> fields = new ArrayList<>();
 
-	private DarwinCoreCoreOrExtension(CoreOrExtension type) {
-		this.type = type;
-	}
+    private DarwinCoreCoreOrExtension(CoreOrExtension type) {
+        this.type = type;
+    }
 
-	private DarwinCoreCoreOrExtension(CoreOrExtension type, Attributes attributes) {
-		this(type);
-		for (int i = 0; i < attributes.getLength(); i++) {
-			// String namespace = attributes.getURI(i);
-			String localName = attributes.getLocalName(i);
-			if (DarwinCoreArchiveConstants.ROW_TYPE.equals(localName)) {
-				this.setRowType(attributes.getValue(i));
-			} else if (DarwinCoreArchiveConstants.FIELDS_TERMINATED_BY.equals(localName)) {
-				this.setFieldsTerminatedBy(attributes.getValue(i));
-			} else if (DarwinCoreArchiveConstants.LINES_TERMINATED_BY.equals(localName)) {
-				this.setLinesTerminatedBy(attributes.getValue(i));
-			} else if (DarwinCoreArchiveConstants.FIELDS_ENCLOSED_BY.equals(localName)) {
-				this.setFieldsEnclosedBy(attributes.getValue(i));
-			} else if (DarwinCoreArchiveConstants.ENCODING.equals(localName)) {
-				this.setEncoding(Charset.forName(attributes.getValue(i)));
-			} else if (DarwinCoreArchiveConstants.IGNORE_HEADER_LINES.equals(localName)) {
-				this.setIgnoreHeaderLines(Integer.parseInt(attributes.getValue(i)));
-			} else if (DarwinCoreArchiveConstants.DATE_FORMAT.equals(localName)) {
-				// Need to change capital D and Y from spec into lower-case
-				// d and y for DateTimeFormatter
-				String nextValue = attributes.getValue(i).replaceAll("D", "d").replaceAll("Y", "y");
-				this.setDateFormat(nextValue);
-			} else {
-				System.out.println("Found unrecognised Darwin Core attribute for " + this.type.toString().toLowerCase()
-						+ " : " + localName);
-			}
-		}
-	}
+    private DarwinCoreCoreOrExtension(CoreOrExtension type, Attributes attributes) {
+        this(type);
+        for (int i = 0; i < attributes.getLength(); i++) {
+            // String namespace = attributes.getURI(i);
+            String localName = attributes.getLocalName(i);
+            if (DarwinCoreArchiveConstants.ROW_TYPE.equals(localName)) {
+                this.setRowType(attributes.getValue(i));
+            } else if (DarwinCoreArchiveConstants.FIELDS_TERMINATED_BY.equals(localName)) {
+                this.setFieldsTerminatedBy(attributes.getValue(i));
+            } else if (DarwinCoreArchiveConstants.LINES_TERMINATED_BY.equals(localName)) {
+                this.setLinesTerminatedBy(attributes.getValue(i));
+            } else if (DarwinCoreArchiveConstants.FIELDS_ENCLOSED_BY.equals(localName)) {
+                this.setFieldsEnclosedBy(attributes.getValue(i));
+            } else if (DarwinCoreArchiveConstants.ENCODING.equals(localName)) {
+                this.setEncoding(Charset.forName(attributes.getValue(i)));
+            } else if (DarwinCoreArchiveConstants.IGNORE_HEADER_LINES.equals(localName)) {
+                this.setIgnoreHeaderLines(Integer.parseInt(attributes.getValue(i)));
+            } else if (DarwinCoreArchiveConstants.DATE_FORMAT.equals(localName)) {
+                // Need to change capital D and Y from spec into lower-case
+                // d and y for DateTimeFormatter to match the Unicode standard
+                String nextValue = attributes.getValue(i).replaceAll("D", "d").replaceAll("Y", "y");
+                this.setDateFormat(nextValue);
+            } else {
+                System.out.println("Found unrecognised Darwin Core attribute for "
+                        + this.type.toString().toLowerCase() + " : " + localName);
+            }
+        }
+    }
 
-	public static DarwinCoreCoreOrExtension newCore() {
-		return new DarwinCoreCoreOrExtension(CoreOrExtension.CORE);
-	}
+    public static DarwinCoreCoreOrExtension newCore() {
+        return new DarwinCoreCoreOrExtension(CoreOrExtension.CORE);
+    }
 
-	public static DarwinCoreCoreOrExtension newExtension() {
-		return new DarwinCoreCoreOrExtension(CoreOrExtension.EXTENSION);
-	}
+    public static DarwinCoreCoreOrExtension newCore(Attributes attributes) {
+        return new DarwinCoreCoreOrExtension(CoreOrExtension.CORE, attributes);
+    }
 
-	public static DarwinCoreCoreOrExtension newCore(Attributes attributes) {
-		return new DarwinCoreCoreOrExtension(CoreOrExtension.CORE, attributes);
-	}
+    public static DarwinCoreCoreOrExtension newExtension() {
+        return new DarwinCoreCoreOrExtension(CoreOrExtension.EXTENSION);
+    }
 
-	public static DarwinCoreCoreOrExtension newExtension(Attributes attributes) {
-		return new DarwinCoreCoreOrExtension(CoreOrExtension.EXTENSION, attributes);
-	}
+    public static DarwinCoreCoreOrExtension newExtension(Attributes attributes) {
+        return new DarwinCoreCoreOrExtension(CoreOrExtension.EXTENSION, attributes);
+    }
 
-	public String getIdOrCoreId() {
-		if (this.idOrCoreId == null && this.type == CoreOrExtension.EXTENSION) {
-			throw new IllegalStateException("Extensions must have coreId value set.");
-		}
-		return idOrCoreId;
-	}
+    public String getIdOrCoreId() {
+        if (this.idOrCoreId == null && this.type == CoreOrExtension.EXTENSION) {
+            throw new IllegalStateException("Extensions must have coreId value set.");
+        }
+        return idOrCoreId;
+    }
 
-	public void setIdOrCoreId(String idOrCoreId) {
-		if (this.idOrCoreId != null && !this.idOrCoreId.equals(idOrCoreId)) {
-			throw new IllegalStateException("Multiple values found for id/coreId");
-		}
-		this.idOrCoreId = idOrCoreId;
-	}
+    public void setIdOrCoreId(String idOrCoreId) {
+        if (this.idOrCoreId != null && !this.idOrCoreId.equals(idOrCoreId)) {
+            throw new IllegalStateException("Multiple values found for id/coreId");
+        }
+        this.idOrCoreId = idOrCoreId;
+    }
 
-	public String getRowType() {
-		if (this.rowType == null) {
-			throw new IllegalStateException("Did not find value for row type that was required");
-		}
-		return rowType;
-	}
+    public String getRowType() {
+        if (this.rowType == null) {
+            throw new IllegalStateException("Did not find value for row type that was required");
+        }
+        return rowType;
+    }
 
-	public void setRowType(String rowType) {
-		if (this.rowType != null && !this.rowType.equals(rowType)) {
-			throw new IllegalStateException("Multiple values found for row type");
-		}
-		this.rowType = rowType;
-	}
+    public void setRowType(String rowType) {
+        if (this.rowType != null && !this.rowType.equals(rowType)) {
+            throw new IllegalStateException("Multiple values found for row type");
+        }
+        this.rowType = rowType;
+    }
 
-	public String getFieldsTerminatedBy() {
-		return fieldsTerminatedBy;
-	}
+    public String getFieldsTerminatedBy() {
+        return fieldsTerminatedBy;
+    }
 
-	public void setFieldsTerminatedBy(String fieldsTerminatedBy) {
-		this.fieldsTerminatedBy = fieldsTerminatedBy.replace("\\t", "\t").replace("\\b", "\b");
-	}
+    public void setFieldsTerminatedBy(String fieldsTerminatedBy) {
+        this.fieldsTerminatedBy = fieldsTerminatedBy.replace("\\t", "\t").replace("\\b", "\b");
+    }
 
-	public String getLinesTerminatedBy() {
-		return linesTerminatedBy;
-	}
+    public String getLinesTerminatedBy() {
+        return linesTerminatedBy;
+    }
 
-	public void setLinesTerminatedBy(String linesTerminatedBy) {
-		this.linesTerminatedBy = linesTerminatedBy.replace("\\n", DEFAULT_LINES_TERMINATED_BY).replace("\\r", "\r");
-	}
+    public void setLinesTerminatedBy(String linesTerminatedBy) {
+        this.linesTerminatedBy = linesTerminatedBy.replace("\\n", DEFAULT_LINES_TERMINATED_BY)
+                .replace("\\r", "\r");
+    }
 
-	public String getFieldsEnclosedBy() {
-		return fieldsEnclosedBy;
-	}
+    public String getFieldsEnclosedBy() {
+        return fieldsEnclosedBy;
+    }
 
-	public void setFieldsEnclosedBy(String fieldsEnclosedBy) {
-		this.fieldsEnclosedBy = fieldsEnclosedBy;
-	}
+    public void setFieldsEnclosedBy(String fieldsEnclosedBy) {
+        this.fieldsEnclosedBy = fieldsEnclosedBy;
+    }
 
-	public Charset getEncoding() {
-		return encoding;
-	}
+    public Charset getEncoding() {
+        return encoding;
+    }
 
-	public void setEncoding(Charset encoding) {
-		this.encoding = encoding;
-	}
+    public void setEncoding(Charset encoding) {
+        this.encoding = encoding;
+    }
 
-	public int getIgnoreHeaderLines() {
-		return ignoreHeaderLines;
-	}
+    public int getIgnoreHeaderLines() {
+        return ignoreHeaderLines;
+    }
 
-	public void setIgnoreHeaderLines(int ignoreHeaderLines) {
-		this.ignoreHeaderLines = ignoreHeaderLines;
-	}
+    public void setIgnoreHeaderLines(int ignoreHeaderLines) {
+        this.ignoreHeaderLines = ignoreHeaderLines;
+    }
 
-	public DateTimeFormatter getDateFormatter() {
-		return dateFormatter;
-	}
+    public DateTimeFormatter getDateFormatter() {
+        return dateFormatter;
+    }
 
-	public String getDateFormat() {
-		return this.dateFormatPattern;
-	}
+    public String getDateFormat() {
+        return this.dateFormatPattern;
+    }
 
-	public void setDateFormat(String nextDateFormatPattern) {
-		this.dateFormatPattern = nextDateFormatPattern;
-		this.dateFormatter = DateTimeFormatter.ofPattern(nextDateFormatPattern);
-	}
+    public void setDateFormat(String nextDateFormatPattern) {
+        this.dateFormatPattern = nextDateFormatPattern;
+        this.dateFormatter = DateTimeFormatter.ofPattern(nextDateFormatPattern);
+    }
 
-	public CoreOrExtension getType() {
-		return type;
-	}
+    public CoreOrExtension getType() {
+        return type;
+    }
 
-	public DarwinCoreFile getFiles() {
-		if (this.files == null) {
-			throw new IllegalStateException("Did not find value for files that was required");
-		}
-		return files;
-	}
+    public DarwinCoreFile getFiles() {
+        if (this.files == null) {
+            throw new IllegalStateException("Did not find value for files that was required");
+        }
+        return files;
+    }
 
-	public void setFiles(DarwinCoreFile files) {
-		if (this.files != null) {
-			throw new IllegalStateException("Only a single files is allowed for each core or extension.");
-		}
-		this.files = files;
-	}
+    public void setFiles(DarwinCoreFile files) {
+        if (this.files != null) {
+            throw new IllegalStateException(
+                    "Only a single files is allowed for each core or extension.");
+        }
+        this.files = files;
+    }
 
-	public List<DarwinCoreField> getFields() {
-		if (this.fields.isEmpty()) {
-			throw new IllegalStateException("No fields present");
-		}
-		return Collections.unmodifiableList(this.fields);
-	}
+    public List<DarwinCoreField> getFields() {
+        if (this.fields.isEmpty()) {
+            throw new IllegalStateException("No fields present");
+        }
+        return Collections.unmodifiableList(this.fields);
+    }
 
-	public void addField(DarwinCoreField nextField) {
-		this.fields.add(nextField);
-	}
+    public void addField(DarwinCoreField nextField) {
+        this.fields.add(nextField);
+    }
 
-	/**
-	 * Write this object as a Darwin Core XML object.
-	 * 
-	 * @param writer
-	 *            The {@link XMLStreamWriter} to write the values to.
-	 * @param showDefaults
-	 *            True to show some default values, for increased
-	 *            interoperability with buggy implementations.
-	 * @throws XMLStreamException
-	 *             If there is an issue with the writing of the XML.
-	 * @throws IOException
-	 *             If there is a file writing issue.
-	 */
-	public void toXML(XMLStreamWriter writer, boolean showDefaults) throws XMLStreamException, IOException {
-		if (this.type == CoreOrExtension.CORE) {
-			writer.writeStartElement(DarwinCoreArchiveConstants.CORE);
-		} else if (this.type == CoreOrExtension.EXTENSION) {
-			writer.writeStartElement(DarwinCoreArchiveConstants.EXTENSION);
-		}
-		writer.writeAttribute(DarwinCoreArchiveConstants.ROW_TYPE, this.getRowType());
-		if (showDefaults || this.getFieldsTerminatedBy() != DEFAULT_FIELDS_TERMINATED_BY) {
-			writer.writeAttribute(DarwinCoreArchiveConstants.FIELDS_TERMINATED_BY, this.getFieldsTerminatedBy());
-		}
-		if (showDefaults || this.getLinesTerminatedBy() != DEFAULT_LINES_TERMINATED_BY) {
-			writer.writeAttribute(DarwinCoreArchiveConstants.LINES_TERMINATED_BY,
-					this.getLinesTerminatedBy().replace("\r", "\\r").replace("\n", "\\n"));
-		}
-		if (showDefaults || this.getFieldsEnclosedBy() != DEFAULT_FIELDS_ENCLOSED_BY) {
-			writer.writeAttribute(DarwinCoreArchiveConstants.FIELDS_ENCLOSED_BY, this.getFieldsEnclosedBy());
-		}
-		if (showDefaults || this.getEncoding() != DEFAULT_ENCODING) {
-			writer.writeAttribute(DarwinCoreArchiveConstants.ENCODING, this.getEncoding().displayName(Locale.ENGLISH));
-		}
-		if (showDefaults || this.getIgnoreHeaderLines() != DEFAULT_IGNORE_HEADER_LINES) {
-			writer.writeAttribute(DarwinCoreArchiveConstants.IGNORE_HEADER_LINES,
-					Integer.toString(this.getIgnoreHeaderLines()));
-		}
-		if (showDefaults || this.getDateFormat() != DEFAULT_DATE_FORMAT_PATTERN) {
-			writer.writeAttribute(DarwinCoreArchiveConstants.DATE_FORMAT,
-					this.getDateFormat().replace("d", "D").replace("y", "Y"));
-		}
-		writer.writeStartElement(DarwinCoreArchiveConstants.FILES);
-		for (String nextLocation : this.getFiles().getLocations()) {
-			writer.writeStartElement(DarwinCoreArchiveConstants.LOCATION);
-			writer.writeCharacters(nextLocation);
-			// end location
-			writer.writeEndElement();
-		}
-		// end files
-		writer.writeEndElement();
-		String coreId = this.getIdOrCoreId();
-		if (coreId != null) {
-			if (this.type == CoreOrExtension.CORE) {
-				writer.writeStartElement(DarwinCoreArchiveConstants.ID);
-			} else if (this.type == CoreOrExtension.EXTENSION) {
-				writer.writeStartElement(DarwinCoreArchiveConstants.COREID);
-			}
-			writer.writeAttribute(DarwinCoreArchiveConstants.INDEX, coreId);
-			// end id
-			writer.writeEndElement();
-		}
-		for (DarwinCoreField nextField : this.getFields()) {
-			writer.writeStartElement(DarwinCoreArchiveConstants.FIELD);
-			if (nextField.getIndex() != null) {
-				writer.writeAttribute(DarwinCoreArchiveConstants.INDEX, nextField.getIndex().toString());
-			}
-			writer.writeAttribute(DarwinCoreArchiveConstants.TERM, nextField.getTerm());
-			if (nextField.getDefault() != null) {
-				writer.writeAttribute(DarwinCoreArchiveConstants.DEFAULT, nextField.getDefault());
-			}
-			if (nextField.getVocabulary() != null) {
-				writer.writeAttribute(DarwinCoreArchiveConstants.VOCABULARY, nextField.getVocabulary());
-			}
-			// end field
-			writer.writeEndElement();
-		}
-		// end core
-		writer.writeEndElement();
-	}
+    /**
+     * Write this object as a Darwin Core XML object.
+     * 
+     * @param writer
+     *            The {@link XMLStreamWriter} to write the values to.
+     * @param showDefaults
+     *            True to show some default values, for increased
+     *            interoperability with buggy implementations.
+     * @throws XMLStreamException
+     *             If there is an issue with the writing of the XML.
+     * @throws IOException
+     *             If there is a file writing issue.
+     */
+    public void toXML(XMLStreamWriter writer, boolean showDefaults)
+            throws XMLStreamException, IOException {
+        if (this.type == CoreOrExtension.CORE) {
+            writer.writeStartElement(DarwinCoreArchiveConstants.CORE);
+        } else if (this.type == CoreOrExtension.EXTENSION) {
+            writer.writeStartElement(DarwinCoreArchiveConstants.EXTENSION);
+        }
+        writer.writeAttribute(DarwinCoreArchiveConstants.ROW_TYPE, this.getRowType());
+        if (showDefaults || this.getFieldsTerminatedBy() != DEFAULT_FIELDS_TERMINATED_BY) {
+            writer.writeAttribute(DarwinCoreArchiveConstants.FIELDS_TERMINATED_BY,
+                    this.getFieldsTerminatedBy());
+        }
+        if (showDefaults || this.getLinesTerminatedBy() != DEFAULT_LINES_TERMINATED_BY) {
+            writer.writeAttribute(DarwinCoreArchiveConstants.LINES_TERMINATED_BY,
+                    this.getLinesTerminatedBy().replace("\r", "\\r").replace("\n", "\\n"));
+        }
+        if (showDefaults || this.getFieldsEnclosedBy() != DEFAULT_FIELDS_ENCLOSED_BY) {
+            writer.writeAttribute(DarwinCoreArchiveConstants.FIELDS_ENCLOSED_BY,
+                    this.getFieldsEnclosedBy());
+        }
+        if (showDefaults || this.getEncoding() != DEFAULT_ENCODING) {
+            writer.writeAttribute(DarwinCoreArchiveConstants.ENCODING,
+                    this.getEncoding().displayName(Locale.ENGLISH));
+        }
+        if (showDefaults || this.getIgnoreHeaderLines() != DEFAULT_IGNORE_HEADER_LINES) {
+            writer.writeAttribute(DarwinCoreArchiveConstants.IGNORE_HEADER_LINES,
+                    Integer.toString(this.getIgnoreHeaderLines()));
+        }
+        if (showDefaults || this.getDateFormat() != DEFAULT_DATE_FORMAT_PATTERN) {
+            // The convention used by Darwin Core Archives does not match the
+            // Unicode standard, so we change it here
+            writer.writeAttribute(DarwinCoreArchiveConstants.DATE_FORMAT,
+                    this.getDateFormat().replace("d", "D").replace("y", "Y"));
+        }
+        writer.writeStartElement(DarwinCoreArchiveConstants.FILES);
+        for (String nextLocation : this.getFiles().getLocations()) {
+            writer.writeStartElement(DarwinCoreArchiveConstants.LOCATION);
+            writer.writeCharacters(nextLocation);
+            // end location
+            writer.writeEndElement();
+        }
+        // end files
+        writer.writeEndElement();
+        String coreId = this.getIdOrCoreId();
+        if (coreId != null) {
+            if (this.type == CoreOrExtension.CORE) {
+                writer.writeStartElement(DarwinCoreArchiveConstants.ID);
+            } else if (this.type == CoreOrExtension.EXTENSION) {
+                writer.writeStartElement(DarwinCoreArchiveConstants.COREID);
+            }
+            writer.writeAttribute(DarwinCoreArchiveConstants.INDEX, coreId);
+            // end id
+            writer.writeEndElement();
+        }
+        for (DarwinCoreField nextField : this.getFields()) {
+            writer.writeStartElement(DarwinCoreArchiveConstants.FIELD);
+            if (nextField.getIndex() != null) {
+                writer.writeAttribute(DarwinCoreArchiveConstants.INDEX,
+                        nextField.getIndex().toString());
+            }
+            writer.writeAttribute(DarwinCoreArchiveConstants.TERM, nextField.getTerm());
+            if (nextField.getDefault() != null) {
+                writer.writeAttribute(DarwinCoreArchiveConstants.DEFAULT, nextField.getDefault());
+            }
+            if (nextField.getVocabulary() != null) {
+                writer.writeAttribute(DarwinCoreArchiveConstants.VOCABULARY,
+                        nextField.getVocabulary());
+            }
+            // end field
+            writer.writeEndElement();
+        }
+        // end core
+        writer.writeEndElement();
+    }
+
+    public CsvSchema getCsvSchema() {
+        Builder result = CsvSchema.builder();
+        // CsvSchema does not support numeric numbers of lines being skipped
+        // Hence, headers are dealt with separately by CSVStream using its
+        // headerLineCount and substituteHeaders parameters, and this is false
+        result.setUseHeader(false);
+        result.setLineSeparator(getLinesTerminatedBy());
+        result.setQuoteChar(getFieldsEnclosedBy().charAt(0));
+        result.setColumnSeparator(getFieldsTerminatedBy().charAt(0));
+        // Darwin Core Archives do not support escape characters so we disable
+        // them completely here
+        result.disableEscapeChar();
+        return result.build();
+    }
 }

--- a/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
+++ b/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
@@ -312,7 +312,7 @@ public class DarwinCoreArchiveCheckerTest {
         Path testOutput = Files.createTempDirectory(testTempDir, "check-output");
         DarwinCoreArchiveChecker.main("--input", testMetadataXmlTsv.toAbsolutePath().toString(), "--output",
                 testOutput.toAbsolutePath().toString());
-        assertTrue(Files.exists(testOutput.resolve("Statistics-specimens.tsv")));
+        assertTrue(Files.exists(testOutput.resolve("Statistics-specimens.tsv"))); 
         assertTrue(Files.exists(testOutput.resolve("Mapping-specimens.tsv")));
     }
 

--- a/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
+++ b/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
@@ -76,6 +76,10 @@ public class DarwinCoreArchiveCheckerTest {
 
     private Path testMetadataXmlWhalesTxt;
 
+    private Path testMetadataXmlTypesCsv;
+
+    private Path testMetadataXmlDistributionCsv;
+
     @Before
     public void setUp() throws Exception {
         testTempDir = tempDir.newFolder("dwca-check-temp").toPath();
@@ -150,12 +154,22 @@ public class DarwinCoreArchiveCheckerTest {
         testMetadataXmlWithExtension = testMetadataXmlWithExtensionFolder
                 .resolve(DarwinCoreArchiveChecker.METADATA_XML);
         testMetadataXmlWhalesTxt = testMetadataXmlWithExtensionFolder.resolve("whales.txt");
+        testMetadataXmlTypesCsv = testMetadataXmlWithExtensionFolder.resolve("types.csv");
+        testMetadataXmlDistributionCsv = testMetadataXmlWithExtensionFolder.resolve("distribution.csv");
         try (Writer out = Files.newBufferedWriter(testMetadataXmlWithExtension)) {
             IOUtils.copy(this.getClass()
                     .getResourceAsStream("/com/github/ansell/dwca/extensionMetadata.xml"), out);
         }
         try (Writer out = Files.newBufferedWriter(testMetadataXmlWhalesTxt)) {
             IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/whales.txt"),
+                    out);
+        }
+        try (Writer out = Files.newBufferedWriter(testMetadataXmlTypesCsv)) {
+            IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/types.csv"),
+                    out);
+        }
+        try (Writer out = Files.newBufferedWriter(testMetadataXmlDistributionCsv)) {
+            IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/distribution.csv"),
                     out);
         }
     }

--- a/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
+++ b/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
@@ -50,211 +50,250 @@ import org.junit.rules.TemporaryFolder;
  */
 public class DarwinCoreArchiveCheckerTest {
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
 
-	private Path testFile;
+    private Path testFile;
 
-	private Path testFile2;
+    private Path testFile2;
 
-	private Path testFileNoMetadata;
+    private Path testFileNoMetadata;
 
-	private Path testTempDir;
+    private Path testTempDir;
 
-	private Path testMetadataXml;
+    private Path testMetadataXml;
 
-	private Path testMetadataXmlWithExtension;
+    private Path testMetadataXmlWithExtension;
 
-	@Before
-	public void setUp() throws Exception {
-		testTempDir = tempDir.newFolder("dwca-check-temp").toPath();
-		testFile = tempDir.newFolder("dwca-check-input1").toPath().resolve("dwca-test.zip");
-		try (OutputStream out = Files.newOutputStream(testFile, StandardOpenOption.CREATE);
-				ZipOutputStream zipOut = new ZipOutputStream(out, StandardCharsets.UTF_8);) {
-			ZipEntry metadataXml = new ZipEntry(DarwinCoreArchiveChecker.METADATA_XML);
-			zipOut.putNextEntry(metadataXml);
-			IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/metadata.xml"), zipOut);
-			zipOut.closeEntry();
-			ZipEntry specimensCsv = new ZipEntry("specimens.csv");
-			zipOut.putNextEntry(specimensCsv);
-			IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/specimens.csv"), zipOut);
-			zipOut.flush();
-			zipOut.closeEntry();
-			zipOut.flush();
-			out.flush();
-		}
-		testFile2 = tempDir.newFolder("dwca-check-input2").toPath().resolve("dwca-test2.zip");
-		try (OutputStream out = Files.newOutputStream(testFile2, StandardOpenOption.CREATE);
-				ZipOutputStream zipOut = new ZipOutputStream(out, StandardCharsets.UTF_8);) {
-			ZipEntry metaXml = new ZipEntry(DarwinCoreArchiveChecker.META_XML);
-			zipOut.putNextEntry(metaXml);
-			IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/metadata.xml"), zipOut);
-			zipOut.closeEntry();
-			ZipEntry specimensCsv = new ZipEntry("specimens.csv");
-			zipOut.putNextEntry(specimensCsv);
-			IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/specimens.csv"), zipOut);
-			zipOut.flush();
-			zipOut.closeEntry();
-			zipOut.flush();
-			out.flush();
-		}
-		testFileNoMetadata = tempDir.newFolder("dwca-check-input3").toPath().resolve("dwca-test-no-metadata.zip");
-		try (OutputStream out = Files.newOutputStream(testFileNoMetadata, StandardOpenOption.CREATE);
-				ZipOutputStream zipOut = new ZipOutputStream(out, StandardCharsets.UTF_8);) {
-			ZipEntry specimensCsv = new ZipEntry("specimens.csv");
-			zipOut.putNextEntry(specimensCsv);
-			IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/specimens.csv"), zipOut);
-			zipOut.flush();
-			zipOut.closeEntry();
-			zipOut.flush();
-			out.flush();
-		}
-		testMetadataXml = tempDir.newFolder("dwca-check-unittest").toPath()
-				.resolve(DarwinCoreArchiveChecker.METADATA_XML);
-		try (Writer out = Files.newBufferedWriter(testMetadataXml)) {
-			IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/metadata.xml"), out);
-		}
-		testMetadataXmlWithExtension = tempDir.newFolder("dwca-check-unittest-with-extensions").toPath()
-				.resolve(DarwinCoreArchiveChecker.METADATA_XML);
-		try (Writer out = Files.newBufferedWriter(testMetadataXmlWithExtension)) {
-			IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/extensionMetadata.xml"), out);
-		}
-	}
+    private Path testMetadataXmlFolder;
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
-	 * .
-	 */
-	@Test
-	public final void testMainHelp() throws Exception {
-		DarwinCoreArchiveChecker.main("--help");
-	}
+    private Path testMetadataXmlSpecimensCsv;
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
-	 * .
-	 */
-	@Test
-	public final void testMain() throws Exception {
-		DarwinCoreArchiveChecker.main("--input", testFile.toAbsolutePath().toString());
-	}
+    private Path testMetadataXmlWithExtensionFolder;
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
-	 * .
-	 */
-	@Test
-	public final void testMainDebug() throws Exception {
-		DarwinCoreArchiveChecker.main("--input", testFile.toAbsolutePath().toString(), "--debug", "true");
-	}
+    private Path testMetadataXmlWhalesTxt;
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
-	 * .
-	 */
-	@Test
-	public final void testMainAlternate() throws Exception {
-		DarwinCoreArchiveChecker.main("--input", testFile2.toAbsolutePath().toString());
-	}
+    @Before
+    public void setUp() throws Exception {
+        testTempDir = tempDir.newFolder("dwca-check-temp").toPath();
+        testFile = tempDir.newFolder("dwca-check-input1").toPath().resolve("dwca-test.zip");
+        try (OutputStream out = Files.newOutputStream(testFile, StandardOpenOption.CREATE);
+                ZipOutputStream zipOut = new ZipOutputStream(out, StandardCharsets.UTF_8);) {
+            ZipEntry metadataXml = new ZipEntry(DarwinCoreArchiveChecker.METADATA_XML);
+            zipOut.putNextEntry(metadataXml);
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/metadata.xml"),
+                    zipOut);
+            zipOut.closeEntry();
+            ZipEntry specimensCsv = new ZipEntry("specimens.csv");
+            zipOut.putNextEntry(specimensCsv);
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/specimens.csv"),
+                    zipOut);
+            zipOut.flush();
+            zipOut.closeEntry();
+            zipOut.flush();
+            out.flush();
+        }
+        testFile2 = tempDir.newFolder("dwca-check-input2").toPath().resolve("dwca-test2.zip");
+        try (OutputStream out = Files.newOutputStream(testFile2, StandardOpenOption.CREATE);
+                ZipOutputStream zipOut = new ZipOutputStream(out, StandardCharsets.UTF_8);) {
+            ZipEntry metaXml = new ZipEntry(DarwinCoreArchiveChecker.META_XML);
+            zipOut.putNextEntry(metaXml);
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/metadata.xml"),
+                    zipOut);
+            zipOut.closeEntry();
+            ZipEntry specimensCsv = new ZipEntry("specimens.csv");
+            zipOut.putNextEntry(specimensCsv);
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/specimens.csv"),
+                    zipOut);
+            zipOut.flush();
+            zipOut.closeEntry();
+            zipOut.flush();
+            out.flush();
+        }
+        testFileNoMetadata = tempDir.newFolder("dwca-check-input3").toPath()
+                .resolve("dwca-test-no-metadata.zip");
+        try (OutputStream out = Files.newOutputStream(testFileNoMetadata,
+                StandardOpenOption.CREATE);
+                ZipOutputStream zipOut = new ZipOutputStream(out, StandardCharsets.UTF_8);) {
+            ZipEntry specimensCsv = new ZipEntry("specimens.csv");
+            zipOut.putNextEntry(specimensCsv);
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/specimens.csv"),
+                    zipOut);
+            zipOut.flush();
+            zipOut.closeEntry();
+            zipOut.flush();
+            out.flush();
+        }
+        testMetadataXmlFolder = tempDir.newFolder("dwca-check-unittest").toPath();
+        testMetadataXml = testMetadataXmlFolder.resolve(DarwinCoreArchiveChecker.METADATA_XML);
+        testMetadataXmlSpecimensCsv = testMetadataXmlFolder.resolve("specimens.csv");
+        try (Writer out = Files.newBufferedWriter(testMetadataXml)) {
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/metadata.xml"),
+                    out);
+        }
+        try (Writer out = Files.newBufferedWriter(testMetadataXmlSpecimensCsv)) {
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/specimens.csv"),
+                    out);
+        }
+        testMetadataXmlWithExtensionFolder = tempDir
+                .newFolder("dwca-check-unittest-with-extensions").toPath();
+        testMetadataXmlWithExtension = testMetadataXmlWithExtensionFolder
+                .resolve(DarwinCoreArchiveChecker.METADATA_XML);
+        testMetadataXmlWhalesTxt = testMetadataXmlWithExtensionFolder.resolve("whales.txt");
+        try (Writer out = Files.newBufferedWriter(testMetadataXmlWithExtension)) {
+            IOUtils.copy(this.getClass()
+                    .getResourceAsStream("/com/github/ansell/dwca/extensionMetadata.xml"), out);
+        }
+        try (Writer out = Files.newBufferedWriter(testMetadataXmlWhalesTxt)) {
+            IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/whales.txt"),
+                    out);
+        }
+    }
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
-	 * .
-	 */
-	@Test
-	public final void testMainNoMetadata() throws Exception {
-		thrown.expect(IllegalStateException.class);
-		thrown.expectMessage("Did not find a metadata file in the ZIP file");
-		DarwinCoreArchiveChecker.main("--input", testFileNoMetadata.toAbsolutePath().toString());
-	}
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainHelp() throws Exception {
+        DarwinCoreArchiveChecker.main("--help");
+    }
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
-	 * .
-	 */
-	@Test
-	public final void testMainBasicMetadata() throws Exception {
-		DarwinCoreArchiveChecker.main("--input", testMetadataXml.toAbsolutePath().toString());
-	}
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMain() throws Exception {
+        DarwinCoreArchiveChecker.main("--input", testFile.toAbsolutePath().toString());
+    }
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
-	 * .
-	 */
-	@Test
-	public final void testMainBasicMetadataWithExtension() throws Exception {
-		DarwinCoreArchiveChecker.main("--input", testMetadataXmlWithExtension.toAbsolutePath().toString());
-	}
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainDebug() throws Exception {
+        DarwinCoreArchiveChecker.main("--input", testFile.toAbsolutePath().toString(), "--debug",
+                "true");
+    }
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#checkZip(java.nio.file.Path, java.nio.file.Path)}
-	 * .
-	 */
-	@Test
-	public final void testCheckZip() throws Exception {
-		Path metadataPath = DarwinCoreArchiveChecker.checkZip(testFile, testTempDir);
-		assertNotNull(metadataPath);
-		assertTrue(Files.exists(metadataPath));
-	}
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainAlternate() throws Exception {
+        DarwinCoreArchiveChecker.main("--input", testFile2.toAbsolutePath().toString());
+    }
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#parseMetadataXml(java.nio.file.Path)}
-	 * .
-	 */
-	@Test
-	public final void testParseMetadataXmlCoreOnly() throws Exception {
-		DarwinCoreArchiveDocument testDocument = DarwinCoreArchiveChecker.parseMetadataXml(testMetadataXml);
-		assertNotNull(testDocument);
-		assertNotNull(testDocument.getCore());
-		assertEquals("http://rs.tdwg.org/dwc/xsd/simpledarwincore/SimpleDarwinRecord",
-				testDocument.getCore().getRowType());
-		assertEquals(1, testDocument.getCore().getIgnoreHeaderLines());
-		assertEquals(0, testDocument.getExtensions().size());
-		assertNotNull(testDocument.getCore().getFiles());
-		assertEquals(1, testDocument.getCore().getFiles().getLocations().size());
-		assertEquals("./specimens.csv", testDocument.getCore().getFiles().getLocations().get(0));
-		assertEquals(4, testDocument.getCore().getFields().size());
-		for (DarwinCoreField field : testDocument.getCore().getFields()) {
-			assertTrue(field.getTerm().trim().length() > 0);
-		}
-	}
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainNoMetadata() throws Exception {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Did not find a metadata file in the ZIP file");
+        DarwinCoreArchiveChecker.main("--input", testFileNoMetadata.toAbsolutePath().toString());
+    }
 
-	/**
-	 * Test method for
-	 * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#parseMetadataXml(java.nio.file.Path)}
-	 * .
-	 */
-	@Test
-	public final void testParseMetadataXmlWithExtensions() throws Exception {
-		DarwinCoreArchiveDocument testDocument = DarwinCoreArchiveChecker
-				.parseMetadataXml(testMetadataXmlWithExtension);
-		assertNotNull(testDocument);
-		assertNotNull(testDocument.getCore());
-		assertEquals("http://rs.tdwg.org/dwc/terms/Taxon", testDocument.getCore().getRowType());
-		assertEquals(1, testDocument.getCore().getIgnoreHeaderLines());
-		assertEquals(StandardCharsets.UTF_8, testDocument.getCore().getEncoding());
-		assertEquals("\n", testDocument.getCore().getLinesTerminatedBy());
-		assertEquals("\t", testDocument.getCore().getFieldsTerminatedBy());
-		assertEquals(2, testDocument.getExtensions().size());
-		assertNotNull(testDocument.getCore().getFiles());
-		assertEquals(1, testDocument.getCore().getFiles().getLocations().size());
-		assertEquals("whales.txt", testDocument.getCore().getFiles().getLocations().get(0));
-		assertEquals(6, testDocument.getCore().getFields().size());
-		for (DarwinCoreField field : testDocument.getCore().getFields()) {
-			assertTrue(field.getTerm().trim().length() > 0);
-		}
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainBasicMetadata() throws Exception {
+        DarwinCoreArchiveChecker.main("--input", testMetadataXml.toAbsolutePath().toString());
+    }
 
-	}
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainBasicMetadataWithExtension() throws Exception {
+        DarwinCoreArchiveChecker.main("--input",
+                testMetadataXmlWithExtension.toAbsolutePath().toString());
+    }
+
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#checkZip(java.nio.file.Path, java.nio.file.Path)}
+     * .
+     */
+    @Test
+    public final void testCheckZip() throws Exception {
+        Path metadataPath = DarwinCoreArchiveChecker.checkZip(testFile, testTempDir);
+        assertNotNull(metadataPath);
+        assertTrue(Files.exists(metadataPath));
+    }
+
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#parseMetadataXml(java.nio.file.Path)}
+     * .
+     */
+    @Test
+    public final void testParseMetadataXmlCoreOnly() throws Exception {
+        DarwinCoreArchiveDocument testDocument = DarwinCoreArchiveChecker
+                .parseMetadataXml(testMetadataXml);
+        assertNotNull(testDocument);
+        assertNotNull(testDocument.getCore());
+        assertEquals("http://rs.tdwg.org/dwc/xsd/simpledarwincore/SimpleDarwinRecord",
+                testDocument.getCore().getRowType());
+        assertEquals(1, testDocument.getCore().getIgnoreHeaderLines());
+        assertEquals(0, testDocument.getExtensions().size());
+        assertNotNull(testDocument.getCore().getFiles());
+        assertEquals(1, testDocument.getCore().getFiles().getLocations().size());
+        assertEquals("./specimens.csv", testDocument.getCore().getFiles().getLocations().get(0));
+        assertEquals(4, testDocument.getCore().getFields().size());
+        for (DarwinCoreField field : testDocument.getCore().getFields()) {
+            assertTrue(field.getTerm().trim().length() > 0);
+        }
+    }
+
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#parseMetadataXml(java.nio.file.Path)}
+     * .
+     */
+    @Test
+    public final void testParseMetadataXmlWithExtensions() throws Exception {
+        DarwinCoreArchiveDocument testDocument = DarwinCoreArchiveChecker
+                .parseMetadataXml(testMetadataXmlWithExtension);
+        assertNotNull(testDocument);
+        assertNotNull(testDocument.getCore());
+        assertEquals("http://rs.tdwg.org/dwc/terms/Taxon", testDocument.getCore().getRowType());
+        assertEquals(1, testDocument.getCore().getIgnoreHeaderLines());
+        assertEquals(StandardCharsets.UTF_8, testDocument.getCore().getEncoding());
+        assertEquals("\n", testDocument.getCore().getLinesTerminatedBy());
+        assertEquals("\t", testDocument.getCore().getFieldsTerminatedBy());
+        assertEquals(2, testDocument.getExtensions().size());
+        assertNotNull(testDocument.getCore().getFiles());
+        assertEquals(1, testDocument.getCore().getFiles().getLocations().size());
+        assertEquals("whales.txt", testDocument.getCore().getFiles().getLocations().get(0));
+        assertEquals(6, testDocument.getCore().getFields().size());
+        for (DarwinCoreField field : testDocument.getCore().getFields()) {
+            assertTrue(field.getTerm().trim().length() > 0);
+        }
+
+    }
 }

--- a/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
+++ b/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
@@ -80,6 +80,12 @@ public class DarwinCoreArchiveCheckerTest {
 
     private Path testMetadataXmlDistributionCsv;
 
+    private Path testMetadataXmlTsvFolder;
+
+    private Path testMetadataXmlTsv;
+
+    private Path testMetadataXmlSpecimensTsv;
+
     @Before
     public void setUp() throws Exception {
         testTempDir = tempDir.newFolder("dwca-check-temp").toPath();
@@ -172,6 +178,19 @@ public class DarwinCoreArchiveCheckerTest {
         try (Writer out = Files.newBufferedWriter(testMetadataXmlDistributionCsv)) {
             IOUtils.copy(
                     this.getClass().getResourceAsStream("/com/github/ansell/dwca/distribution.csv"),
+                    out);
+        }
+        testMetadataXmlTsvFolder = tempDir.newFolder("dwca-check-unittest-tsv").toPath();
+        testMetadataXmlTsv = testMetadataXmlTsvFolder.resolve(DarwinCoreArchiveChecker.METADATA_XML);
+        testMetadataXmlSpecimensTsv = testMetadataXmlTsvFolder.resolve("specimens.tsv");
+        try (Writer out = Files.newBufferedWriter(testMetadataXmlTsv)) {
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/tsvmetadata.xml"),
+                    out);
+        }
+        try (Writer out = Files.newBufferedWriter(testMetadataXmlSpecimensTsv)) {
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/specimens.tsv"),
                     out);
         }
     }
@@ -281,6 +300,20 @@ public class DarwinCoreArchiveCheckerTest {
         assertTrue(Files.exists(testOutput.resolve("Mapping-types.csv")));
         assertTrue(Files.exists(testOutput.resolve("Statistics-whales.txt")));
         assertTrue(Files.exists(testOutput.resolve("Mapping-whales.txt")));
+    }
+
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainTsvMetadataWithOutput() throws Exception {
+        Path testOutput = Files.createTempDirectory(testTempDir, "check-output");
+        DarwinCoreArchiveChecker.main("--input", testMetadataXmlTsv.toAbsolutePath().toString(), "--output",
+                testOutput.toAbsolutePath().toString());
+        assertTrue(Files.exists(testOutput.resolve("Statistics-specimens.tsv")));
+        assertTrue(Files.exists(testOutput.resolve("Mapping-specimens.tsv")));
     }
 
     /**

--- a/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
+++ b/src/test/java/com/github/ansell/dwca/DarwinCoreArchiveCheckerTest.java
@@ -155,7 +155,8 @@ public class DarwinCoreArchiveCheckerTest {
                 .resolve(DarwinCoreArchiveChecker.METADATA_XML);
         testMetadataXmlWhalesTxt = testMetadataXmlWithExtensionFolder.resolve("whales.txt");
         testMetadataXmlTypesCsv = testMetadataXmlWithExtensionFolder.resolve("types.csv");
-        testMetadataXmlDistributionCsv = testMetadataXmlWithExtensionFolder.resolve("distribution.csv");
+        testMetadataXmlDistributionCsv = testMetadataXmlWithExtensionFolder
+                .resolve("distribution.csv");
         try (Writer out = Files.newBufferedWriter(testMetadataXmlWithExtension)) {
             IOUtils.copy(this.getClass()
                     .getResourceAsStream("/com/github/ansell/dwca/extensionMetadata.xml"), out);
@@ -169,7 +170,8 @@ public class DarwinCoreArchiveCheckerTest {
                     out);
         }
         try (Writer out = Files.newBufferedWriter(testMetadataXmlDistributionCsv)) {
-            IOUtils.copy(this.getClass().getResourceAsStream("/com/github/ansell/dwca/distribution.csv"),
+            IOUtils.copy(
+                    this.getClass().getResourceAsStream("/com/github/ansell/dwca/distribution.csv"),
                     out);
         }
     }
@@ -246,6 +248,39 @@ public class DarwinCoreArchiveCheckerTest {
     public final void testMainBasicMetadataWithExtension() throws Exception {
         DarwinCoreArchiveChecker.main("--input",
                 testMetadataXmlWithExtension.toAbsolutePath().toString());
+    }
+
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainBasicMetadataWithOutput() throws Exception {
+        Path testOutput = Files.createTempDirectory(testTempDir, "check-output");
+        DarwinCoreArchiveChecker.main("--input", testMetadataXml.toAbsolutePath().toString(), "--output",
+                testOutput.toAbsolutePath().toString());
+        assertTrue(Files.exists(testOutput.resolve("Statistics-specimens.csv")));
+        assertTrue(Files.exists(testOutput.resolve("Mapping-specimens.csv")));
+    }
+
+    /**
+     * Test method for
+     * {@link com.github.ansell.dwca.DarwinCoreArchiveChecker#main(java.lang.String[])}
+     * .
+     */
+    @Test
+    public final void testMainBasicMetadataWithExtensionWithOutput() throws Exception {
+        Path testOutput = Files.createTempDirectory(testTempDir, "check-output");
+        DarwinCoreArchiveChecker.main("--input",
+                testMetadataXmlWithExtension.toAbsolutePath().toString(), "--output",
+                testOutput.toAbsolutePath().toString());
+        assertTrue(Files.exists(testOutput.resolve("Statistics-distribution.csv")));
+        assertTrue(Files.exists(testOutput.resolve("Mapping-distribution.csv")));
+        assertTrue(Files.exists(testOutput.resolve("Statistics-types.csv")));
+        assertTrue(Files.exists(testOutput.resolve("Mapping-types.csv")));
+        assertTrue(Files.exists(testOutput.resolve("Statistics-whales.txt")));
+        assertTrue(Files.exists(testOutput.resolve("Mapping-whales.txt")));
     }
 
     /**

--- a/src/test/resources/com/github/ansell/dwca/specimens.tsv
+++ b/src/test/resources/com/github/ansell/dwca/specimens.tsv
@@ -1,0 +1,3 @@
+ID	Species	Count	DatasetID
+123	'Cryptantha gypsophila Reveal & C.R. Broome'	12	A1
+124	Buxbaumia piperi	2	A1

--- a/src/test/resources/com/github/ansell/dwca/tsvmetadata.xml
+++ b/src/test/resources/com/github/ansell/dwca/tsvmetadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive xmlns="http://rs.tdwg.org/dwc/text/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xsi:schemaLocation="http://rs.tdwg.org/dwc/text/ http://rs.tdwg.org/dwc/text/tdwg_dwc_text.xsd">
+  <core rowType="http://rs.tdwg.org/dwc/xsd/simpledarwincore/SimpleDarwinRecord" ignoreHeaderLines="1" 
+            fieldsTerminatedBy="\t" linesTerminatedBy="\r\n" fieldsEnclosedBy="'">
+    <files>
+      <location>./specimens.tsv</location>
+    </files>
+    <field index="0" term="http://rs.tdwg.org/dwc/terms/catalogNumber" />
+    <field index="1" term="http://rs.tdwg.org/dwc/terms/scientificName" />
+    <field index="2" term="http://rs.tdwg.org/dwc/terms/individualCount" />
+    <!-- A constant value has no index, but applies to all rows -->
+    <field term="http://rs.tdwg.org/dwc/terms/datasetID" default="urn:lsid:tim.lsid.tdwg.org:collections:1"/>
+  </core>
+</archive>


### PR DESCRIPTION
Pushes information about quote/separator/line ending characters from the metadata.xml file down into the CSV parser.

Also fixes #5 